### PR TITLE
Another browser sync example added

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var gulp = require('gulp'),
 gulp.task('connect-sync', function() {
   connect.server({}, function (){
     browserSync({
-      proxy: 'localhost:8000'
+      proxy: '127.0.0.1:8000'
     });
   });
 

--- a/examples/browser-sync-02/gulpfile.js
+++ b/examples/browser-sync-02/gulpfile.js
@@ -1,0 +1,26 @@
+var gulp = require('gulp'),
+    connect = require('../../index.js'),
+    browserSync = require('browser-sync');
+
+
+//task that fires up php server at port 8001
+gulp.task('connect', function(callback) {
+  connect.server({
+    port: 8001
+  }, callback);
+});
+
+
+//task that fires up browserSync proxy after connect server has started
+gulp.task('browser-sync',['connect'], function() {
+    browserSync({
+      proxy: '127.0.0.1:8001',
+      port: 8910
+  });
+});
+
+
+//default task that runs task browser-sync ones and then watches php files to change. If they change browserSync is reloaded
+gulp.task('default', ['browser-sync'], function () {
+  gulp.watch(['**/*.php'], browserSync.reload);
+});

--- a/examples/browser-sync-02/index.php
+++ b/examples/browser-sync-02/index.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Browser Sync Example 02</title>
+</head>
+<body>
+	<p><?php echo "hello PHP world :)"; ?></p>
+
+	<a href="link.php">Link to next page</a>
+	
+</body>
+</html>

--- a/examples/browser-sync-02/link.php
+++ b/examples/browser-sync-02/link.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Browser Sync Example 02</title>
+</head>
+<body>
+	<p><?php echo "Hopefuly we are still at browserSync proxy port 8910:))"; ?></p>
+
+	<a href="index.php">Link to previous page</a>
+	
+</body>
+</html>

--- a/examples/browser-sync-02/package.json
+++ b/examples/browser-sync-02/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "browser-sync-test",
+  "version": "1.0.1",
+  "description": "",
+  "main": "gulpfile.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "browser-sync": "^2.0.0-rc9",
+    "gulp": "^3.8.10"
+  }
+}


### PR DESCRIPTION
Browser sync must be configured with ip (127.0.0.1) instead of localhost or it will break links from time to time (mostly happened to me on more complicated sites with more links).
Related to [this](https://github.com/BrowserSync/browser-sync/issues/335)
This simple example checks if the browser-sync linking between pages is OK also browserSync is updated to newer version. 

Don't bash me if i mess up something. Its my first pull request ever :)
