### PR TITLE
Add option to configure stdio of php server process

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,8 @@ module.exports = (function () {
 			keepalive: false,
 			open: false,
 			bin: 'php',
-			root: '/'
+			root: '/',
+			stdio: 'inherit'
 		}, options);
 
 		var host = options.hostname + ':' + options.port;
@@ -108,7 +109,7 @@ module.exports = (function () {
 
 			var cp = spawn(options.bin, args, {
 				cwd: options.base,
-				stdio: 'inherit'
+				stdio: options.stdio
 			});
 
 			// check when the server is ready. tried doing it by listening


### PR DESCRIPTION
Several people (myself included) have expressed a desire to control the verbosity of the output of the php built-in server process, which by default logs all resource requests to stdout.

This pull request simply surfaces the lower-level spawn option for stdio, allowing stdin, out, and err to be independently configured as documented here: https://nodejs.org/api/child_process.html#child_process_options_stdio

Personally, I just set it to 'ignore' :-)
