### PR TITLE
Wait for base to exist before spawning php bin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,11 +106,19 @@ module.exports = (function () {
 				return;
 			}
 
-			var cp = spawn(options.bin, args, {
-				cwd: options.base,
-				stdio: 'inherit'
-			});
-
+			var checkPath = function(){
+			    var exists = fs.existsSync(options.base);
+			    if (exists === true) {
+			        spawn(options.bin, args, {
+						cwd: options.base,
+						stdio: 'inherit'
+					});
+			    }
+			    else{
+			    	setTimeout(checkPath, 100); 
+			    }
+			}
+			checkPath(); 
 			// check when the server is ready. tried doing it by listening
 			// to the child process `data` event, but it's not triggered...
 			checkServer(options.hostname, options.port, function () {


### PR DESCRIPTION
We run various apps in a build directory that gets wiped whenever we start up gulp tasks for serving. On every restart kept hitting `events.js:72 throw er; // Unhandled 'error' event` unless the dir path already existed. 
