### PR TITLE
Wait for base to exist before spawning php bin.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec;
 var http = require('http');
 var open = require('opn');
 var binVersionCheck = require('bin-version-check');
-var fs = requires('fs');
+var fs = require('fs');
 
 module.exports = (function () {
 	var checkServerTries = 0;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var exec = require('child_process').exec;
 var http = require('http');
 var open = require('opn');
 var binVersionCheck = require('bin-version-check');
+var fs = requires('fs');
 
 module.exports = (function () {
 	var checkServerTries = 0;

--- a/index.js
+++ b/index.js
@@ -106,11 +106,19 @@ module.exports = (function () {
 				return;
 			}
 
-			var cp = spawn(options.bin, args, {
-				cwd: options.base,
-				stdio: 'inherit'
-			});
-
+			var checkPath = function(){
+			    var exists = fs.existsSync(options.base);
+			    if (exists === true) {
+			        spawn(options.bin, args, {
+						cwd: options.base,
+						stdio: 'inherit'
+					});
+			    }
+			    else{
+			    	setTimeout(checkPath, 100); 
+			    }
+			}
+			checkPath(); 
 			// check when the server is ready. tried doing it by listening
 			// to the child process `data` event, but it's not triggered...
 			checkServer(options.hostname, options.port, function () {


### PR DESCRIPTION
Our use of a build directory includes wiping it when changing apps/restarting. This results in `events.js:72 throw er; // Unhandled 'error' event`. Waiting for existence of dir before spawn fixes the issue. 
