### PR TITLE
fix base options

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = (function () {
 			    var exists = fs.existsSync(options.base);
 			    if (exists === true) {
 			        spawn(options.bin, args, {
-						cwd: options.base,
+						//cwd: options.base,
 						stdio: options.stdio
 					});
 			    }

--- a/index.js
+++ b/index.js
@@ -103,6 +103,10 @@ module.exports = (function () {
 		if (options.router) {
 			args.push(options.router);
 		}
+		
+		if (options.base) {
+			args.push('-t', options.base);
+		}
 
 		binVersionCheck(options.bin, '>=5.4', function (err) {
 			if (err) {


### PR DESCRIPTION
Nice jobs ! Very useful gulp task !

The base option don't work for me ! 
I try this. now the option work. 

```

var gulp = require('gulp'),
    connect = require('gulp-connect-php'),
    browserSync = require('browser-sync');

gulp.task('connect-sync', function() {
  connect.server({
    base: 'src/' //  <--- my php app folder 
  }, function (){
    browserSync({
      proxy: 'localhost:8000'
    });
  });

  gulp.watch('src/**/*.php').on('change', function () {
    browserSync.reload();
  });
});

//  dev task and sub-task
gulp.task('serve', ['connect-sync']);


```
