### PR TITLE
Adding minimum Node requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # gulp-connect-php
 
+***REQUIRES NODE 5.0.0 OR GREATER***
+
 > Start a [PHP-server](http://php.net/manual/en/features.commandline.webserver.php)
 
 This is pretty much a gulp version of [@sindresorhus's](https://github.com/sindresorhus) [grunt-php](https://github.com/sindresorhus/grunt-php) and acts as a _basic version_ drop-in replacement for [gulp-connect](https://www.npmjs.com/package/gulp-connect), though please note not all features from gulp-connect are supported with gulp-connect-php. I am open to supporting other features and pull requests that implement them.
@@ -122,7 +124,7 @@ Windows Batch file execution via a `%PATH%` specified batchfile is possible, but
 ```batch
 @echo off
 
-REM We specify the whole path to PHP since the working directory is that of gulp... 
+REM We specify the whole path to PHP since the working directory is that of gulp...
 REM unless we also changed that in our gulp callback.
 
 C:\Users\mainuser\Applications\PHP\7.0.17-NTS-VC14\php.exe %*
@@ -134,7 +136,7 @@ gulp.task('connect', function _gulp_connect_task() {
   connect.server({
     configCallback: function _configCallback(type, collection) {
       if (type === connect.OPTIONS_SPAWN_OBJ) {
-        // Windows Batch files are NOT executable on their own. This will start a shell 
+        // Windows Batch files are NOT executable on their own. This will start a shell
         // session then execute.
         collection.shell = true;
         return collection;
@@ -227,10 +229,10 @@ Type: `function (type, collection) : collection`
 Prototype:
 
   - `type` - String, either `OPTIONS_SPAWN_OBJ` or `OPTIONS_PHP_CLI_ARR`.
-  - `collection` - Array or Object, the initial version of the collection specified by `type`. 
+  - `collection` - Array or Object, the initial version of the collection specified by `type`.
 
      Return: Optionally modified version of `collection`.
-  
+
 Default: `'null'` (Which is replaced with a no-op call that returns an unmodified version of the `collection` parameter)
 
 Allows the caller to modify the `spawn` [options](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) object and or the [PHP command line arguments](http://php.net/manual/en/features.commandline.options.php) (array) before the [PHP development server](http://php.net/manual/en/features.commandline.webserver.php) is invoked.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "gulp-connect-php",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Starts a php server",
   "main": "index.js",
+  "engines" : { "node" : ">=5.0.0" },
   "scripts": {
     "test": "mocha ./test"
   },
@@ -26,7 +27,7 @@
     "opn": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
-    "supertest": "^0.15.0"
+    "mocha": "^3.2.0",
+    "supertest": "^3.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -20,9 +20,9 @@ const noopReturn = function _noopReturn(x) { return x; };
 describe('gulp-connect-php', function _base_suite1() {
 
   it('Should start a basic php server', function _test_basic(done) {
-    connect.server({}, function _basic_serverCallback(error) {
+    connect.server({port: 8001}, function _basic_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8000')
+      request('http://127.0.0.1:8001')
         .get('/test/fixtures/hello.php')
         .expect(/hello world/)
         .expect(200)
@@ -45,9 +45,9 @@ describe('gulp-connect-php', function _base_suite1() {
     const conn1 = new connect();
     const conn2 = new connect();
 
-    conn1.server({port: 8001}, function _multiples1_serverCallback(error) {
+    conn1.server({port: 8002}, function _multiples1_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8001')
+      request('http://127.0.0.1:8002')
         .get('/test/fixtures/hello.php')
         .expect(/hello world/)
         .expect(200)
@@ -59,9 +59,9 @@ describe('gulp-connect-php', function _base_suite1() {
         });
     });
 
-    conn2.server({port: 8002}, function _multiples2_serverCallback(error) {
+    conn2.server({port: 8003}, function _multiples2_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8002')
+      request('http://127.0.0.1:8003')
         .get('/test/fixtures/hello.php')
         .expect(/hello world/)
         .expect(200)
@@ -76,6 +76,7 @@ describe('gulp-connect-php', function _base_suite1() {
 
   it('Should start a basic php server, with a set environment variable and updated memory limits set via the configCallback option', function _test_configCallback(done) {
     connect.server({
+      port: 8004,
       configCallback: function _configCallback(type, collection) {
         if (type === connect.OPTIONS_SPAWN_OBJ) {
           collection.env = Object.assign({
@@ -92,7 +93,7 @@ describe('gulp-connect-php', function _base_suite1() {
       }
     }, function _configCallback_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8000')
+      request('http://127.0.0.1:8004')
         .get('/test/fixtures/config-cb-checker.php')
         .expect(/ENVVAR=SET_OK,MEM_LIMIT=2\.1G;/)
         .expect(200)
@@ -106,9 +107,9 @@ describe('gulp-connect-php', function _base_suite1() {
   });
 
   it('Should start a basic php server without a close callback', function _test_basicNoCloseCB(done) {
-    connect.server({}, function _basicNoCloseCB_serverCallback(error) {
+    connect.server({port: 8005}, function _basicNoCloseCB_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8000')
+      request('http://127.0.0.1:8005')
         .get('/test/fixtures/hello.php')
         .expect(/hello world/)
         .expect(200)
@@ -122,6 +123,7 @@ describe('gulp-connect-php', function _base_suite1() {
 
   it('Should start a basic php server, with a set environment variable and updated memory limits set via the configCallback option with null', function _test_configCallback(done) {
     connect.server({
+      port: 8006,
       configCallback: function _configCallback(type, collection) {
         if (type === connect.OPTIONS_SPAWN_OBJ) {
           collection.env = Object.assign({
@@ -135,7 +137,7 @@ describe('gulp-connect-php', function _base_suite1() {
       }
     }, function _configCallback_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8000')
+      request('http://127.0.0.1:8006')
         .get('/test/fixtures/config-cb-checker.php')
         .expect(/ENVVAR=SET_OK,MEM_LIMIT=2\.1G;/)
         .expect(200)
@@ -150,6 +152,7 @@ describe('gulp-connect-php', function _base_suite1() {
 
   it('Should start a basic php server, with a set environment variable and updated memory limits set via the configCallback option with no return', function _test_configCallback(done) {
     connect.server({
+      port: 8007,
       configCallback: function _configCallback(type, collection) {
         if (type === connect.OPTIONS_SPAWN_OBJ) {
           collection.env = Object.assign({
@@ -161,7 +164,7 @@ describe('gulp-connect-php', function _base_suite1() {
       }
     }, function _configCallback_serverCallback(error) {
       if (error) throw error;
-      request('http://127.0.0.1:8000')
+      request('http://127.0.0.1:8007')
         .get('/test/fixtures/config-cb-checker.php')
         .expect(/ENVVAR=SET_OK,MEM_LIMIT=2\.1G;/)
         .expect(200)
@@ -173,5 +176,4 @@ describe('gulp-connect-php', function _base_suite1() {
         });
     });
   });
-
 });


### PR DESCRIPTION
# Notes
Largely to address https://github.com/micahblu/gulp-connect-php/issues/42. 

However tests were updated to not have overlaping port numbers as well, since server instances dont always shutdown the timespan of the gap between each test, this would also allow for future parallel testing, though it was implemented in this case to allow the combination of [testen](https://github.com/egoist/testen) and [nvm](https://github.com/creationix/nvm) help me determine the minimum Node version required... The test was run agains all of the current [green](http://node.green) released primaries.

## Install Versions
```sh
array=( '7.9.0' '7.5.0' '6.10.2' '6.4.0' '5.12.0' '4.8.2' '0.12.18' '0.10.48' )
for i in "${array[@]}"; do nvm install "$i"; done
```

## Invoke Test (via testen)

```
gulp-connect-php$ ./node_modules/testen/testen -n 7.9.0 -n 7.5.0 -n 6.10.2 -n 6.4.0 \
    -n 5.12.0 -n 4.8.2 -n 0.12.18 -n 0.10.48
```
