### PR TITLE
fix npm prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test-compat": "npm run __anchor; mocha ./test",
     "test-normative": "npm run __anchor; GCP_ES6=1 mocha ./test",
     "test": "npm run test-normative; npm run test-compat",
-    "prepack": "npm run __anchor; ./convert.sh"
+    "prepack": "npm run __anchor && npm i; ./convert.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
`npm prepack` doesn't work correctly if dependencies aren't installed.
Now, [npm package](https://www.npmjs.com/package/gulp-connect-php) is broken – `index-compact.js` is empty.
Also, `npm prepack` is firing before installing dependencies, when you geting it from github. In this way, `npm i` will run twice, but at least it will be installed correctly.
Maybe, it will be more elegant to change process of packing.